### PR TITLE
Increase OSLC_TRESHOLD a bit

### DIFF
--- a/license_check.py
+++ b/license_check.py
@@ -86,7 +86,9 @@ def parse_oslc_output(source, output, result, pelc_license_mapping):
     P_LICENSE_STATS = 4
     P_FILES = 5
 
-    OSLC_TRESHOLD = 33
+    # Licenses detected with probability less than OSLC_TRESHOLD are dismissed.
+    # Value is based on some observations.
+    OSLC_TRESHOLD = 39
 
     status = P_BEGIN
     lnumber = 0


### PR DESCRIPTION
I know we could shuffle this value ad infinitum and never find a perfect match, but based on some observations when investigating #9 I think increasing it a bit shouldn't do any harm.